### PR TITLE
feat: add local test server and UI improvements

### DIFF
--- a/core/deep_search.py
+++ b/core/deep_search.py
@@ -1,0 +1,319 @@
+import asyncio
+from datetime import datetime, timedelta
+from typing import Dict, List, Any, Optional, Tuple
+import re
+from utils.logger import bot_logger
+from utils.db import DatabaseManager, with_database
+from pathlib import Path
+from core.season import SeasonManager, SeasonConfig
+from difflib import SequenceMatcher
+
+class DeepSearch:
+    """深度搜索功能类"""
+    
+    def __init__(self):
+        """初始化深度搜索"""
+        # 数据库路径
+        self.db_path = Path("data/deep_search.db")
+        
+        # 冷却时间（秒）
+        self.cooldown_seconds = 15
+        
+        # 最小查询字符长度
+        self.min_query_length = 3
+        
+        # 用户冷却时间记录
+        self.user_cooldowns: Dict[str, datetime] = {}
+        
+        # 初始化数据库管理器
+        self.db = DatabaseManager(self.db_path)
+        
+        # 初始化赛季管理器
+        self.season_manager = SeasonManager()
+        
+    async def start(self):
+        """启动深度搜索服务"""
+        bot_logger.info("[DeepSearch] 启动深度搜索服务")
+        
+        # 确保数据库已初始化
+        await self._init_db()
+        
+        # 初始化赛季管理器
+        await self.season_manager.initialize()
+    
+    async def _init_db(self):
+        """初始化SQLite数据库"""
+        # 确保数据目录存在
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # 定义表创建SQL
+        tables = [
+            # 搜索记录表
+            '''CREATE TABLE IF NOT EXISTS search_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                query TEXT NOT NULL,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )''',
+            
+            # 搜索结果缓存表
+            '''CREATE TABLE IF NOT EXISTS search_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                query TEXT NOT NULL,
+                results TEXT NOT NULL,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )'''
+        ]
+        
+        # 创建表
+        for table_sql in tables:
+            await self.db.execute_simple(table_sql)
+        
+        bot_logger.debug("[DeepSearch] 数据库初始化完成")
+    
+    async def is_on_cooldown(self, user_id: str) -> Tuple[bool, int]:
+        """检查用户是否处于冷却状态
+        
+        Args:
+            user_id: 用户ID
+            
+        Returns:
+            Tuple[bool, int]: (是否处于冷却, 剩余冷却时间(秒))
+        """
+        now = datetime.now()
+        if user_id in self.user_cooldowns:
+            last_time = self.user_cooldowns[user_id]
+            elapsed = (now - last_time).total_seconds()
+            
+            if elapsed < self.cooldown_seconds:
+                remaining = int(self.cooldown_seconds - elapsed)
+                return True, remaining
+        
+        return False, 0
+    
+    async def set_cooldown(self, user_id: str):
+        """设置用户冷却时间
+        
+        Args:
+            user_id: 用户ID
+        """
+        self.user_cooldowns[user_id] = datetime.now()
+    
+    async def validate_query(self, query: str) -> Tuple[bool, str]:
+        """验证搜索查询是否合法
+        
+        Args:
+            query: 搜索查询
+            
+        Returns:
+            Tuple[bool, str]: (是否合法, 错误信息)
+        """
+        # 去除空白字符和/ds前缀
+        query = query.strip()
+        if query.lower().startswith("/ds"):
+            query = query[3:].strip()
+            bot_logger.debug(f"[DeepSearch] 去除/ds前缀后的查询: {query}")
+        
+        # 检查长度
+        if len(query) < self.min_query_length:
+            bot_logger.debug(f"[DeepSearch] 查询长度不足: {len(query)}/{self.min_query_length}")
+            return False, f"查询ID至少需要{self.min_query_length}个字符"
+            
+        # 检查是否包含至少三个英文字母
+        letters = re.findall(r'[a-zA-Z]', query)
+        if len(letters) < 3:
+            bot_logger.debug(f"[DeepSearch] 英文字母数量不足: {len(letters)}/3")
+            return False, "查询ID必须包含至少三个英文字母"
+        
+        bot_logger.debug(f"[DeepSearch] 查询验证通过: {query}")
+        return True, ""
+    
+    def _get_name_base(self, name: str) -> str:
+        """获取名称的基础部分（去除#后的部分）"""
+        return name.split("#")[0] if "#" in name else name
+    
+    def _calculate_similarity(self, name: str, query: str) -> float:
+        """使用difflib计算字符串相似度"""
+        name = name.lower()
+        query = query.lower()
+        
+        # 获取基础名称
+        name_base = self._get_name_base(name)
+        query_base = self._get_name_base(query)
+        
+        # 使用SequenceMatcher计算相似度
+        matcher = SequenceMatcher(None, name_base, query_base)
+        similarity = matcher.ratio()
+        
+        # 首字匹配加权
+        if name_base.startswith(query_base):
+            similarity = max(similarity, 0.8)  # 确保首字匹配至少有0.8的相似度
+            
+        return similarity
+    
+    @with_database
+    async def search(self, query: str) -> List[Dict[str, Any]]:
+        """执行深度搜索
+        
+        Args:
+            query: 搜索查询
+            
+        Returns:
+            List[Dict[str, Any]]: 搜索结果列表
+        """
+        results = []
+        first_char_matches = []  # 首字匹配结果
+        contains_matches = []    # 包含匹配结果
+        
+        try:
+            # 获取当前赛季实例
+            season = await self.season_manager.get_season(SeasonConfig.CURRENT_SEASON)
+            if not season:
+                return results
+                
+            # 获取所有玩家数据
+            all_players = await season.get_all_players()
+            if not all_players:
+                return results
+                
+            # 转换查询为小写
+            query_lower = query.lower()
+            query_base = self._get_name_base(query_lower)
+            
+            # 处理每个玩家
+            for player_data in all_players:
+                try:
+                    player_name = player_data.get("name", "").lower()
+                    if not player_name:
+                        continue
+                        
+                    # 获取所有可能的名称
+                    names = [
+                        player_name,
+                        player_data.get("steamName", "").lower(),
+                        player_data.get("psnName", "").lower(),
+                        player_data.get("xboxName", "").lower()
+                    ]
+                    
+                    # 计算最佳匹配分数
+                    best_similarity = 0
+                    is_first_char_match = False
+                    
+                    for name in names:
+                        if not name:  # 跳过空名称
+                            continue
+                            
+                        # 检查是否是首字匹配
+                        name_base = self._get_name_base(name)
+                        if name_base.startswith(query_base):
+                            is_first_char_match = True
+                            
+                        similarity = self._calculate_similarity(name, query_lower)
+                        best_similarity = max(best_similarity, similarity)
+                    
+                    # 如果相似度太低，跳过
+                    if best_similarity < 0.3:
+                        continue
+                        
+                    # 创建结果对象
+                    player_result = {
+                        "id": player_data["name"],
+                        "rank": best_similarity,
+                        "season": SeasonConfig.CURRENT_SEASON.upper(),
+                        "game_rank": player_data.get("rank"),
+                        "score": player_data.get("rankScore", player_data.get("fame", 0)),
+                        "platforms": {
+                            "steam": player_data.get("steamName", ""),
+                            "psn": player_data.get("psnName", ""),
+                            "xbox": player_data.get("xboxName", "")
+                        }
+                    }
+                    
+                    # 根据匹配类型分类
+                    if is_first_char_match:
+                        first_char_matches.append(player_result)
+                    else:
+                        contains_matches.append(player_result)
+                        
+                except Exception as e:
+                    bot_logger.warning(f"[DeepSearch] 处理玩家数据时出错: {str(e)}")
+                    continue
+                    
+            # 分别对两类结果按相似度排序
+            first_char_matches.sort(key=lambda x: (-x["rank"], x["id"].lower()))
+            contains_matches.sort(key=lambda x: (-x["rank"], x["id"].lower()))
+            
+            # 合并结果，首字匹配优先
+            results = first_char_matches + contains_matches
+            
+            # 限制结果数量
+            results = results[:10]
+            
+            # 记录搜索结果到数据库
+            await self._save_search_history(query, results)
+            
+        except Exception as e:
+            bot_logger.error(f"[DeepSearch] 搜索数据时出错: {str(e)}")
+            
+        return results
+    
+    @with_database
+    async def _save_search_history(self, query: str, results: List[Dict[str, Any]]) -> None:
+        """保存搜索历史到数据库
+        
+        Args:
+            query: 搜索查询
+            results: 搜索结果
+        """
+        # 保存搜索结果
+        import json
+        results_json = json.dumps(results)
+        await self.db.execute_simple(
+            "INSERT INTO search_results (query, results) VALUES (?, ?)",
+            (query, results_json)
+        )
+    
+    @with_database
+    async def add_search_history(self, user_id: str, query: str) -> None:
+        """添加用户搜索历史
+        
+        Args:
+            user_id: 用户ID
+            query: 搜索查询
+        """
+        await self.db.execute_simple(
+            "INSERT INTO search_history (user_id, query) VALUES (?, ?)",
+            (user_id, query)
+        )
+    
+    async def format_search_results(self, query: str, results: List[Dict[str, Any]]) -> str:
+        """格式化搜索结果消息
+        
+        Args:
+            query: 搜索查询
+            results: 搜索结果
+            
+        Returns:
+            str: 格式化后的消息
+        """
+        message = f"🔎 深度搜索 | {query.replace('/ds', '').strip()}\n"
+        message += "━━━━━━━━━━━━━\n"
+        
+        if not results:
+            message += "😕 未找到匹配结果\n"
+            message += "━━━━━━━━━━━━━"
+            return message
+        
+        message += "👀 所有结果:\n"
+        
+        for result in results:
+            player_id = result["id"]
+            score = result.get("score", 0)
+            message += f"▎{player_id} [{score}]\n"
+        
+        message += "━━━━━━━━━━━━━"
+        return message
+    
+    async def stop(self):
+        """停止深度搜索服务"""
+        bot_logger.info("[DeepSearch] 停止深度搜索服务") 

--- a/plugins/deep_search_plugin.py
+++ b/plugins/deep_search_plugin.py
@@ -1,0 +1,93 @@
+from core.plugin import Plugin, on_command
+from utils.message_handler import MessageHandler
+from core.deep_search import DeepSearch
+from utils.logger import bot_logger
+import asyncio
+
+class DeepSearchPlugin(Plugin):
+    """深度搜索插件"""
+    
+    def __init__(self):
+        """初始化深度搜索插件"""
+        super().__init__()
+        self.deep_search = DeepSearch()
+        bot_logger.debug(f"[{self.name}] 初始化深度搜索插件")
+    
+    async def on_load(self):
+        """插件加载时的处理"""
+        bot_logger.debug(f"[{self.name}] 开始加载深度搜索插件")
+        await super().on_load()  # 等待父类的 on_load 完成
+        await self.deep_search.start()  # 初始化DeepSearch
+        bot_logger.info(f"[{self.name}] 深度搜索插件已加载")
+    
+    async def on_unload(self):
+        """插件卸载时的处理"""
+        await self.deep_search.stop()  # 停止所有任务
+        await super().on_unload()
+        bot_logger.info(f"[{self.name}] 深度搜索插件已卸载")
+    
+    @on_command("ds", "深度搜索ID")
+    async def handle_deep_search(self, handler: MessageHandler, content: str) -> None:
+        """处理深度搜索命令
+        
+        Args:
+            handler: 消息处理器
+            content: 消息内容
+        """
+        try:
+            # 获取用户ID
+            user_id = handler.message.author.member_openid
+            
+            # 检查用户是否处于冷却状态
+            on_cooldown, remaining = await self.deep_search.is_on_cooldown(user_id)
+            if on_cooldown:
+                error_msg = (
+                    "💡 小贴士: 查询过于频繁\n"
+                    "━━━━━━━━━━━━━\n"
+                    f"需要等待 {remaining} 秒才能再次查询\n"
+                    "请稍后再试"
+                )
+                await handler.send_text(error_msg)
+                return
+            
+            # 去除空白字符
+            query = content.strip()
+            
+            # 验证查询参数
+            is_valid, error_message = await self.deep_search.validate_query(query)
+            
+            if not is_valid:
+                error_msg = (
+                    "💡 小贴士: 查询参数无效\n"
+                    "━━━━━━━━━━━━━\n"
+                    f"{error_message}\n"
+                    "请检查后重试"
+                )
+                await handler.send_text(error_msg)
+                return
+            
+            # 设置用户冷却
+            await self.deep_search.set_cooldown(user_id)
+            
+            # 记录搜索历史
+            await self.deep_search.add_search_history(user_id, query)
+            
+            # 执行搜索
+            results = await self.deep_search.search(query)
+            
+            # 格式化结果并发送
+            response = await self.deep_search.format_search_results(query, results)
+            await handler.send_text(response)
+            
+        except Exception as e:
+            error_msg = (
+                "💡 小贴士: 搜索失败\n"
+                "━━━━━━━━━━━━━\n"
+                "可能的原因:\n"
+                "1. 服务器连接超时\n"
+                "2. 数据暂时不可用\n"
+                "3. 系统正在维护\n"
+                "请稍后重试"
+            )
+            bot_logger.error(f"[{self.name}] 处理深度搜索失败: {str(e)}")
+            await handler.send_text(error_msg) 

--- a/resources/templates/rank.html
+++ b/resources/templates/rank.html
@@ -95,12 +95,11 @@
         }
         
         .title-text {
-            color: #fff;
+            color: #000;
             font-size: 4.5rem;
             font-weight: 900;
             display: flex;
             align-items: center;
-            text-shadow: -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000;
             letter-spacing: 2px;
         }
         
@@ -114,7 +113,7 @@
         /* 内容盒子 */
         .content-box {
             width: 1200px;
-            height: 200px;
+            height: 180px;
             border-radius: 1.5rem;
             padding: 2rem;
             display: flex;
@@ -174,7 +173,6 @@
         }
         
         .rank-icon {
-            filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.5));
             transform: translateZ(0);
         }
         

--- a/tools/check_db.py
+++ b/tools/check_db.py
@@ -1,0 +1,37 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncio
+from utils.db import DatabaseManager
+from pathlib import Path
+
+async def check_database():
+    # 获取所有赛季数据库
+    seasons_db_path = Path("data/persistence")
+    season_dbs = [f for f in seasons_db_path.glob("season_*.db") if f.is_file()]
+    
+    for db_path in season_dbs:
+        print(f"\n检查数据库: {db_path}")
+        db = DatabaseManager(db_path)
+        try:
+            # 获取表结构
+            tables = await db.fetch_all("SELECT name FROM sqlite_master WHERE type='table'")
+            print("\n表结构:")
+            for table in tables:
+                print(f"- {table[0]}")
+            
+            # 获取玩家数据示例
+            players = await db.fetch_all("SELECT player_name, data FROM player_data LIMIT 3")
+            if players:
+                print("\n玩家数据示例:")
+                for player in players:
+                    print(f"\n玩家ID: {player[0]}")
+                    print(f"数据片段: {player[1][:200]}...")
+        except Exception as e:
+            print(f"读取数据库出错: {str(e)}")
+        finally:
+            await db.close()
+
+if __name__ == "__main__":
+    asyncio.run(check_database()) 

--- a/tools/check_db_data.py
+++ b/tools/check_db_data.py
@@ -1,0 +1,58 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncio
+from utils.db import DatabaseManager
+from pathlib import Path
+from utils.logger import bot_logger
+
+async def check_database():
+    try:
+        # 连接数据库
+        db_path = Path("data/persistence/season_s5.db")
+        db = DatabaseManager(db_path)
+        
+        # 检查表是否存在
+        tables = await db.fetch_all("SELECT name FROM sqlite_master WHERE type='table'")
+        print("\n现有表:")
+        for table in tables:
+            print(f"- {table[0]}")
+        
+        # 检查记录数
+        try:
+            count = await db.fetch_one("SELECT COUNT(*) as count FROM player_data")
+            print(f"\n总记录数: {count['count'] if count else 0}")
+        except Exception as e:
+            print(f"\n获取记录数失败: {str(e)}")
+        
+        # 获取示例数据
+        try:
+            print("\n搜索 'Dizzy' 相关记录:")
+            players = await db.fetch_all(
+                """
+                SELECT player_name, data 
+                FROM player_data 
+                WHERE LOWER(player_name) LIKE ? 
+                LIMIT 5
+                """,
+                ("%dizzy%",)
+            )
+            
+            if players:
+                for player in players:
+                    print(f"\n玩家ID: {player[0]}")
+                    print(f"数据: {player[1][:200]}...")
+            else:
+                print("未找到匹配记录")
+                
+        except Exception as e:
+            print(f"\n搜索失败: {str(e)}")
+            
+        await db.close()
+        
+    except Exception as e:
+        print(f"检查数据库出错: {str(e)}")
+
+if __name__ == "__main__":
+    asyncio.run(check_database()) 

--- a/tools/command_tester.html
+++ b/tools/command_tester.html
@@ -1,0 +1,1254 @@
+<!--
+    *Command Tester UI*
+    *This is the UI file for Command Tester, please do not delete this file*
+-->
+
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CommandLine</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap">
+    <style>
+        :root {
+            --primary-color: #0070f3;
+            --primary-hover: #0061d5;
+            --bg-color: #fafafa;
+            --panel-bg: #ffffff;
+            --border-color: #eaeaea;
+            --text-color: #111111;
+            --text-secondary: #666666;
+            --bot-msg-bg: #f0f7ff;
+            --user-msg-bg: #f2f2f7;
+            --error-color: #ff453a;
+            --success-color: #34c759;
+            --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.05);
+            --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+            --radius-sm: 6px;
+            --radius-md: 8px;
+            --radius-lg: 12px;
+            --transition: all 0.2s ease;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --primary-color: #0070f3;
+                --primary-hover: #3291ff;
+                --bg-color: #111111;
+                --panel-bg: #1c1c1e;
+                --border-color: #333333;
+                --text-color: #f2f2f7;
+                --text-secondary: #8e8e93;
+                --bot-msg-bg: #1c1c2e;
+                --user-msg-bg: #2c2c2e;
+            }
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: var(--font-sans);
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            line-height: 1.5;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            gap: 1.5rem;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding-bottom: 1.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        header h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--text-color);
+        }
+
+        .subtitle {
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+            max-width: 500px;
+            animation: fadeIn 0.8s ease-out;
+        }
+
+        .content {
+            display: flex;
+            flex: 1;
+            gap: 1.5rem;
+        }
+
+        .chat-container {
+            flex: 2;
+            display: flex;
+            flex-direction: column;
+            border-radius: var(--radius-lg);
+            overflow: hidden;
+            background-color: var(--panel-bg);
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border-color);
+            transition: var(--transition);
+            animation: slideUp 0.5s ease-out;
+        }
+
+        .chat-container:hover {
+            box-shadow: var(--shadow-md);
+        }
+
+        .sidebar {
+            flex: 1;
+            max-width: 320px;
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+            animation: slideUp 0.7s ease-out;
+            position: sticky;
+            top: 1rem;
+            height: calc(100vh - 2rem);
+            overflow-y: auto;
+            scrollbar-width: thin;
+            scrollbar-color: var(--text-secondary) transparent;
+        }
+
+        .sidebar::-webkit-scrollbar {
+            width: 6px;
+        }
+
+        .sidebar::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        .sidebar::-webkit-scrollbar-thumb {
+            background-color: var(--text-secondary);
+            border-radius: 20px;
+        }
+
+        .panel {
+            background-color: var(--panel-bg);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border-color);
+            overflow: hidden;
+            transition: var(--transition);
+        }
+
+        .panel:hover {
+            box-shadow: var(--shadow-md);
+        }
+
+        .panel-header {
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 1px solid var(--border-color);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .panel-body {
+            padding: 1rem;
+        }
+
+        .command-list-wrapper {
+            max-height: 350px;
+            overflow-y: auto;
+            scrollbar-width: thin;
+            scrollbar-color: var(--text-secondary) transparent;
+        }
+
+        .command-list-wrapper::-webkit-scrollbar {
+            width: 6px;
+        }
+
+        .command-list-wrapper::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        .command-list-wrapper::-webkit-scrollbar-thumb {
+            background-color: var(--text-secondary);
+            border-radius: 20px;
+        }
+
+        .command-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .command-group {
+            margin-bottom: 1.25rem;
+        }
+
+        .command-group-title {
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-secondary);
+            margin-bottom: 0.5rem;
+            font-weight: 600;
+        }
+
+        .command-item {
+            margin-top: 0.5rem;
+            padding: 0.65rem 0.85rem;
+            background-color: var(--bg-color);
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+            transition: var(--transition);
+            border: 1px solid var(--border-color);
+        }
+
+        .command-item:hover {
+            background-color: var(--bot-msg-bg);
+            transform: translateY(-1px);
+        }
+
+        .command-title {
+            font-weight: 500;
+            color: var(--primary-color);
+            font-size: 0.875rem;
+            margin-bottom: 0.25rem;
+        }
+
+        .command-description {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+        }
+
+        .chat-messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 1.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            scrollbar-width: thin;
+            scrollbar-color: var(--text-secondary) transparent;
+        }
+
+        .chat-messages::-webkit-scrollbar {
+            width: 6px;
+        }
+
+        .chat-messages::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        .chat-messages::-webkit-scrollbar-thumb {
+            background-color: var(--text-secondary);
+            border-radius: 20px;
+        }
+
+        .message {
+            max-width: 80%;
+            padding: 0.75rem 1rem;
+            border-radius: var(--radius-md);
+            position: relative;
+            animation: messageAppear 0.3s ease-out;
+            margin-bottom: 2rem;
+        }
+
+        .message-actions {
+            position: absolute;
+            right: 0;
+            bottom: -2rem;
+            display: flex;
+            gap: 0.5rem;
+            opacity: 0;
+            transform: translateY(-5px);
+            transition: all 0.2s ease;
+            height: 1.75rem;
+            z-index: 1;
+        }
+
+        .message:hover .message-actions {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .message-action-btn {
+            height: 1.75rem;
+            padding: 0 0.75rem;
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            background: var(--panel-bg);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+            transition: var(--transition);
+            white-space: nowrap;
+            box-shadow: var(--shadow-sm);
+        }
+
+        .message-action-btn:hover {
+            border-color: var(--primary-color);
+            background: var(--bg-color);
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .message-action-btn svg {
+            width: 0.875rem;
+            height: 0.875rem;
+            fill: currentColor;
+        }
+
+        .clickable-command {
+            color: var(--primary-color);
+            cursor: pointer;
+            text-decoration: underline;
+            transition: var(--transition);
+        }
+
+        .clickable-command:hover {
+            color: var(--primary-hover);
+        }
+
+        .bot-typing {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 1rem;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        .typing-dots {
+            display: flex;
+            gap: 0.25rem;
+        }
+
+        .typing-dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--text-secondary);
+            animation: typingDot 1.4s infinite;
+        }
+
+        .typing-dot:nth-child(2) { animation-delay: 0.2s; }
+        .typing-dot:nth-child(3) { animation-delay: 0.4s; }
+
+        @keyframes typingDot {
+            0%, 60%, 100% { transform: translateY(0); }
+            30% { transform: translateY(-4px); }
+        }
+
+        .user-message {
+            align-self: flex-end;
+            background-color: var(--user-msg-bg);
+            border: 1px solid var(--border-color);
+        }
+
+        .bot-message {
+            align-self: flex-start;
+            background-color: var(--bot-msg-bg);
+            border: 1px solid rgba(0, 112, 243, 0.2);
+        }
+
+        .message-header {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            margin-bottom: 0.5rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .message-avatar {
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            background-color: var(--primary-color);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.625rem;
+            color: white;
+            font-weight: 600;
+        }
+
+        .user-avatar {
+            background-color: var(--text-secondary);
+        }
+
+        .message-content {
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-size: 0.9375rem;
+        }
+
+        .input-container {
+            padding: 1.25rem;
+            border-top: 1px solid var(--border-color);
+            background-color: var(--panel-bg);
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .input-wrapper {
+            display: flex;
+            position: relative;
+            background: var(--bg-color);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-md);
+            transition: var(--transition);
+            box-shadow: var(--shadow-sm);
+            overflow: hidden;
+        }
+
+        .input-wrapper:focus-within {
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(0, 112, 243, 0.2);
+            transform: translateY(-1px);
+        }
+
+        .command-input {
+            flex: 1;
+            padding: 0.875rem 1rem;
+            border: none;
+            border-radius: var(--radius-md);
+            resize: none;
+            font-family: inherit;
+            font-size: 0.9375rem;
+            line-height: 1.5;
+            outline: none;
+            background: transparent;
+            color: var(--text-color);
+            min-height: 3.25rem;
+            max-height: 9.75rem;
+        }
+
+        .command-input::placeholder {
+            color: var(--text-secondary);
+            opacity: 0.7;
+        }
+
+        .send-button {
+            margin: 0.375rem;
+            background-color: var(--primary-color);
+            color: white;
+            border: none;
+            border-radius: var(--radius-md);
+            padding: 0 1.25rem;
+            cursor: pointer;
+            font-size: 0.9375rem;
+            font-weight: 500;
+            transition: var(--transition);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            min-width: 5rem;
+            height: 2.5rem;
+        }
+
+        .send-button svg {
+            width: 1.25rem;
+            height: 1.25rem;
+            transition: transform 0.2s ease;
+            fill: currentColor;
+        }
+
+        .send-button:hover {
+            background-color: var(--primary-hover);
+            transform: translateY(-1px);
+        }
+
+        .send-button:hover svg {
+            transform: translateX(2px);
+        }
+
+        .send-button:disabled {
+            background-color: var(--text-secondary);
+            cursor: not-allowed;
+            transform: none;
+        }
+
+        .send-button:disabled svg {
+            transform: none;
+        }
+
+        .input-tips {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .error-message {
+            background-color: rgba(255, 69, 58, 0.1);
+            color: #d32f2f;
+            padding: 1rem;
+            border-radius: var(--radius-md);
+            margin: 0.5rem 0;
+            font-size: 0.875rem;
+            position: relative;
+            animation: slideIn 0.3s ease-out;
+            border: 1px solid rgba(255, 69, 58, 0.2);
+        }
+
+        .error-message pre {
+            background-color: rgba(0, 0, 0, 0.05);
+            color: #666;
+            padding: 1rem;
+            border-radius: var(--radius-sm);
+            margin-top: 0.5rem;
+            overflow-x: auto;
+            font-family: monospace;
+            font-size: 0.75rem;
+            white-space: pre-wrap;
+            border: 1px solid rgba(0, 0, 0, 0.1);
+        }
+
+        .error-message .copy-button {
+            position: absolute;
+            top: 0.5rem;
+            right: 0.5rem;
+            background-color: rgba(255, 69, 58, 0.1);
+            border: 1px solid rgba(255, 69, 58, 0.2);
+            color: #d32f2f;
+            padding: 0.25rem 0.5rem;
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+            font-size: 0.75rem;
+            transition: var(--transition);
+        }
+
+        .error-message .copy-button:hover {
+            background-color: rgba(255, 69, 58, 0.2);
+        }
+
+        .error-message .error-type {
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            color: #d32f2f;
+        }
+
+        .error-message .error-details {
+            margin-top: 0.75rem;
+            padding-top: 0.75rem;
+            border-top: 1px solid rgba(255, 69, 58, 0.1);
+        }
+
+        @keyframes slideIn {
+            from {
+                opacity: 0;
+                transform: translateY(-10px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .settings-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .setting-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .setting-label {
+            font-size: 0.875rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .setting-icon {
+            width: 1rem;
+            height: 1rem;
+            opacity: 0.7;
+        }
+
+        /* 开关样式 */
+        .toggle {
+            position: relative;
+            display: inline-block;
+            width: 36px;
+            height: 20px;
+        }
+
+        .toggle input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .toggle-slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--border-color);
+            transition: var(--transition);
+            border-radius: 20px;
+        }
+
+        .toggle-slider:before {
+            position: absolute;
+            content: "";
+            height: 16px;
+            width: 16px;
+            left: 2px;
+            bottom: 2px;
+            background-color: white;
+            transition: var(--transition);
+            border-radius: 50%;
+        }
+
+        input:checked + .toggle-slider {
+            background-color: var(--primary-color);
+        }
+
+        input:checked + .toggle-slider:before {
+            transform: translateX(16px);
+        }
+
+        .button {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-md);
+            padding: 0.5rem 1rem;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 500;
+            transition: var(--transition);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            margin-top: 0.5rem;
+        }
+
+        .button:hover {
+            background-color: var(--primary-color);
+            color: white;
+            border-color: var(--primary-color);
+        }
+
+        .loading {
+            display: inline-block;
+            width: 1rem;
+            height: 1rem;
+            border: 2px solid rgba(0, 112, 243, 0.3);
+            border-radius: 50%;
+            border-top-color: var(--primary-color);
+            animation: spin 0.8s linear infinite;
+            margin-right: 0.5rem;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        @keyframes slideUp {
+            from { 
+                opacity: 0;
+                transform: translateY(10px);
+            }
+            to { 
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes messageAppear {
+            from {
+                opacity: 0;
+                transform: translateY(5px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        /* 响应式设计 */
+        @media (max-width: 900px) {
+            .container {
+                padding: 0.75rem;
+                gap: 0.75rem;
+            }
+
+            .content {
+                flex-direction: column;
+            }
+
+            .sidebar {
+                max-width: none;
+                order: -1;
+                position: relative;
+                top: 0;
+                height: auto;
+            }
+
+            .command-list-wrapper {
+                max-height: 180px;
+            }
+        }
+
+        @media (max-width: 600px) {
+            header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.5rem;
+            }
+
+            .message {
+                max-width: 90%;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div style="display: none;">
+        <!-- SVG Sprite -->
+        <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+            <symbol id="icon-retry" viewBox="0 0 24 24">
+                <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/>
+            </symbol>
+            <symbol id="icon-copy" viewBox="0 0 24 24">
+                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+            </symbol>
+            <symbol id="icon-send" viewBox="0 0 24 24">
+                <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+            </symbol>
+            <symbol id="icon-command" viewBox="0 0 24 24">
+                <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z"/>
+            </symbol>
+        </svg>
+    </div>
+    <div class="container">
+        <header>
+            <h1>CommandLine</h1>
+            <p class="subtitle">v0.0.1 Build 202503060109</p>
+        </header>
+        <div class="content">
+            <div class="chat-container">
+                <div class="chat-messages" id="chatMessages">
+                    <div class="message bot-message">
+                        <div class="message-header">
+                            <div class="message-avatar">S</div>
+                            <span>系统</span>
+                        </div>
+                        <div class="message-content">👋 欢迎使用CommandLine。它可以在不启动QQ机器人服务的情况下本地测试所有命令。
+
+请在下方输入框中输入命令，例如 <span class="clickable-command" data-command="/ds Dizzy">/ds Dizzy</span> 来测试深度搜索命令。
+
+你也可以在右侧点击命令快速测试。</div>
+                    </div>
+                </div>
+                <div class="input-container">
+                    <div class="input-wrapper">
+                        <textarea class="command-input" id="commandInput" placeholder="输入命令，例如: /ds Dizzy" rows="2"></textarea>
+                        <button class="send-button" id="sendButton">
+                            <svg><use href="#icon-send"/></svg>
+                            发送
+                        </button>
+                    </div>
+                    <div class="input-tips">
+                        <span>提示: 按Enter发送，Shift+Enter换行</span>
+                        <span id="charCount">0 个字符</span>
+                    </div>
+                </div>
+            </div>
+            <div class="sidebar">
+                <div class="panel">
+                    <div class="panel-header">可用命令</div>
+                    <div class="panel-body">
+                        <div class="command-list-wrapper">
+                            <div class="command-list" id="commandList">
+                                <!-- 命令列表将通过JS动态加载 -->
+                                <div style="display: flex; align-items: center; justify-content: center; padding: 1rem;">
+                                    <div class="loading"></div>
+                                    <span>加载中...</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="panel">
+                    <div class="panel-header">设置</div>
+                    <div class="panel-body">
+                        <div class="settings-list">
+                            <div class="setting-item">
+                                <label class="setting-label" for="showTimestamp">
+                                    <svg class="setting-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M12 8V12L15 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/>
+                                    </svg>
+                                    显示时间戳
+                                </label>
+                                <label class="toggle">
+                                    <input type="checkbox" id="showTimestamp" checked>
+                                    <span class="toggle-slider"></span>
+                                </label>
+                            </div>
+                            <div class="setting-item">
+                                <label class="setting-label" for="autoScroll">
+                                    <svg class="setting-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M12 5V19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <path d="M19 12L12 19L5 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                    </svg>
+                                    自动滚动
+                                </label>
+                                <label class="toggle">
+                                    <input type="checkbox" id="autoScroll" checked>
+                                    <span class="toggle-slider"></span>
+                                </label>
+                            </div>
+                            <div class="setting-item">
+                                <label class="setting-label" for="darkMode">
+                                    <svg class="setting-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M12 3V4M12 20V21M4 12H3M6.31412 6.31412L5.5 5.5M17.6859 6.31412L18.5 5.5M6.31412 17.69L5.5 18.5M17.6859 17.69L18.5 18.5M21 12H20M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                    跟随系统
+                                </label>
+                                <label class="toggle">
+                                    <input type="checkbox" id="darkMode" checked>
+                                    <span class="toggle-slider"></span>
+                                </label>
+                            </div>
+                            <button class="button" id="clearButton">清空聊天记录</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const chatMessages = document.getElementById('chatMessages');
+            const commandInput = document.getElementById('commandInput');
+            const sendButton = document.getElementById('sendButton');
+            const commandList = document.getElementById('commandList');
+            const showTimestamp = document.getElementById('showTimestamp');
+            const autoScroll = document.getElementById('autoScroll');
+            const darkMode = document.getElementById('darkMode');
+            const clearButton = document.getElementById('clearButton');
+            const charCount = document.getElementById('charCount');
+            
+            let isWaitingForResponse = false;
+
+            // 设置暗模式
+            function setColorScheme() {
+                if (darkMode.checked) {
+                    document.body.classList.remove('force-light', 'force-dark');
+                } else {
+                    document.body.classList.add('force-light');
+                    document.body.classList.remove('force-dark');
+                }
+            }
+
+            darkMode.addEventListener('change', setColorScheme);
+            setColorScheme();
+
+            // 字符计数
+            commandInput.addEventListener('input', function() {
+                charCount.textContent = `${this.value.length} 个字符`;
+            });
+
+            // 加载命令列表
+            fetchCommandList();
+
+            // 添加消息到聊天区域
+            function addMessage(content, type, imageData = null) {
+                const messageDiv = document.createElement('div');
+                messageDiv.className = `message ${type}-message`;
+                
+                const header = document.createElement('div');
+                header.className = 'message-header';
+                
+                const avatar = document.createElement('div');
+                avatar.className = `message-avatar ${type === 'user' ? 'user-avatar' : ''}`;
+                avatar.textContent = type === 'user' ? 'U' : 'B';
+                
+                const headerText = document.createElement('span');
+                const timestamp = showTimestamp.checked ? getTimestamp() : '';
+                headerText.textContent = type === 'user' ? `你 ${timestamp}` : `机器人 ${timestamp}`;
+                
+                header.appendChild(avatar);
+                header.appendChild(headerText);
+                
+                const messageContent = document.createElement('div');
+                messageContent.className = 'message-content';
+
+                // 如果是系统消息，处理可点击的命令
+                if (type === 'bot' && content && content.includes('/')) {
+                    const commandRegex = /\/[a-zA-Z]+\s+[^\s]+/g;
+                    let lastIndex = 0;
+                    let match;
+                    let processedContent = '';
+
+                    while ((match = commandRegex.exec(content)) !== null) {
+                        processedContent += content.slice(lastIndex, match.index);
+                        processedContent += `<span class="clickable-command" data-command="${match[0]}">${match[0]}</span>`;
+                        lastIndex = match.index + match[0].length;
+                    }
+                    processedContent += content.slice(lastIndex);
+                    messageContent.innerHTML = processedContent;
+
+                    // 添加点击事件
+                    messageContent.querySelectorAll('.clickable-command').forEach(cmd => {
+                        cmd.addEventListener('click', () => {
+                            const command = cmd.getAttribute('data-command');
+                            commandInput.value = command;
+                            sendCommand();
+                        });
+                    });
+                } else if (content) {
+                    messageContent.textContent = content;
+                }
+                
+                messageDiv.appendChild(header);
+                messageDiv.appendChild(messageContent);
+
+                // 如果有图片数据,添加图片
+                if (imageData) {
+                    const imageContainer = document.createElement('div');
+                    imageContainer.className = 'message-image';
+                    imageContainer.style.cssText = 'margin-top: 10px; max-width: 100%; overflow: hidden; border-radius: 8px;';
+                    
+                    const image = document.createElement('img');
+                    image.src = `data:image/jpeg;base64,${imageData}`;
+                    image.style.cssText = 'max-width: 100%; height: auto; display: block; cursor: pointer;';
+                    image.onclick = () => {
+                        // 创建全屏预览
+                        const preview = document.createElement('div');
+                        preview.style.cssText = `
+                            position: fixed;
+                            top: 0;
+                            left: 0;
+                            right: 0;
+                            bottom: 0;
+                            background: rgba(0, 0, 0, 0.9);
+                            display: flex;
+                            justify-content: center;
+                            align-items: center;
+                            z-index: 1000;
+                            cursor: pointer;
+                        `;
+                        
+                        const previewImg = document.createElement('img');
+                        previewImg.src = image.src;
+                        previewImg.style.cssText = 'max-width: 90%; max-height: 90%; object-fit: contain;';
+                        
+                        preview.appendChild(previewImg);
+                        document.body.appendChild(preview);
+                        
+                        // 点击关闭预览
+                        preview.onclick = () => preview.remove();
+                    };
+                    
+                    imageContainer.appendChild(image);
+                    messageDiv.appendChild(imageContainer);
+                }
+
+                // 添加消息操作按钮
+                const actions = document.createElement('div');
+                actions.className = 'message-actions';
+
+                if (type === 'user') {
+                    // 重试按钮
+                    const retryBtn = document.createElement('button');
+                    retryBtn.className = 'message-action-btn';
+                    retryBtn.innerHTML = '<svg><use href="#icon-retry"/></svg>重试';
+                    retryBtn.addEventListener('click', () => {
+                        commandInput.value = content;
+                        sendCommand();
+                    });
+                    actions.appendChild(retryBtn);
+                }
+
+                // 复制按钮 (对所有消息都添加)
+                const copyBtn = document.createElement('button');
+                copyBtn.className = 'message-action-btn';
+                copyBtn.innerHTML = '<svg><use href="#icon-copy"/></svg>复制';
+                copyBtn.addEventListener('click', () => {
+                    // 如果有图片,复制图片链接
+                    if (imageData) {
+                        const imgUrl = `data:image/jpeg;base64,${imageData}`;
+                        navigator.clipboard.writeText(imgUrl).then(() => {
+                            const originalText = copyBtn.innerHTML;
+                            copyBtn.innerHTML = '<svg><use href="#icon-copy"/></svg>已复制图片链接';
+                            setTimeout(() => {
+                                copyBtn.innerHTML = originalText;
+                            }, 2000);
+                        });
+                    } else {
+                        navigator.clipboard.writeText(content).then(() => {
+                            const originalText = copyBtn.innerHTML;
+                            copyBtn.innerHTML = '<svg><use href="#icon-copy"/></svg>已复制';
+                            setTimeout(() => {
+                                copyBtn.innerHTML = originalText;
+                            }, 2000);
+                        });
+                    }
+                });
+                actions.appendChild(copyBtn);
+                messageDiv.appendChild(actions);
+                
+                chatMessages.appendChild(messageDiv);
+                
+                if (autoScroll.checked) {
+                    scrollToBottom();
+                }
+            }
+
+            // 添加等待动画
+            function addTypingIndicator() {
+                const typingDiv = document.createElement('div');
+                typingDiv.className = 'bot-typing';
+                typingDiv.innerHTML = `
+                    <div class="message-avatar">B</div>
+                    <span>正在输入</span>
+                    <div class="typing-dots">
+                        <div class="typing-dot"></div>
+                        <div class="typing-dot"></div>
+                        <div class="typing-dot"></div>
+                    </div>
+                `;
+                chatMessages.appendChild(typingDiv);
+                if (autoScroll.checked) {
+                    scrollToBottom();
+                }
+                return typingDiv;
+            }
+
+            // 发送命令
+            function sendCommand() {
+                const command = commandInput.value.trim();
+                if (command === '' || isWaitingForResponse) return;
+                
+                // 添加用户消息
+                addMessage(command, 'user');
+                
+                // 清空输入框
+                commandInput.value = '';
+                charCount.textContent = '0 个字符';
+                
+                // 发送请求
+                isWaitingForResponse = true;
+                sendButton.disabled = true;
+                
+                // 添加等待动画
+                const typingIndicator = addTypingIndicator();
+                
+                fetch('/api/execute_command', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ command: command })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    // 移除等待动画
+                    typingIndicator.remove();
+                    
+                    if (data.error) {
+                        addErrorMessage(data.error);
+                    } else {
+                        addMessage(data.response, 'bot', data.image);
+                    }
+                })
+                .catch(error => {
+                    // 移除等待动画
+                    typingIndicator.remove();
+                    
+                    addErrorMessage('服务器连接错误，请检查后端服务是否运行。');
+                    console.error('Error:', error);
+                })
+                .finally(() => {
+                    isWaitingForResponse = false;
+                    sendButton.disabled = false;
+                    commandInput.focus();
+                });
+            }
+
+            // 添加错误消息
+            function addErrorMessage(content) {
+                const errorDiv = document.createElement('div');
+                errorDiv.className = 'error-message';
+                errorDiv.textContent = content;
+                chatMessages.appendChild(errorDiv);
+                
+                if (autoScroll.checked) {
+                    scrollToBottom();
+                }
+            }
+
+            // 获取格式化的时间戳
+            function getTimestamp() {
+                const now = new Date();
+                return `[${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}:${now.getSeconds().toString().padStart(2, '0')}]`;
+            }
+
+            // 滚动到底部
+            function scrollToBottom() {
+                chatMessages.scrollTop = chatMessages.scrollHeight;
+            }
+
+            // 获取命令列表
+            function fetchCommandList() {
+                fetch('/api/command_list')
+                .then(response => response.json())
+                .then(data => {
+                    commandList.innerHTML = '';
+                    
+                    if (data.error) {
+                        const errorDiv = document.createElement('div');
+                        errorDiv.className = 'error-message';
+                        errorDiv.textContent = data.error;
+                        commandList.appendChild(errorDiv);
+                        return;
+                    }
+                    
+                    // 按插件名分组命令
+                    const pluginCommands = {};
+                    
+                    for (const [command, info] of Object.entries(data.commands)) {
+                        const pluginName = info.plugin || '其他';
+                        
+                        if (!pluginCommands[pluginName]) {
+                            pluginCommands[pluginName] = [];
+                        }
+                        
+                        pluginCommands[pluginName].push({
+                            command: command,
+                            description: info.description || '无描述',
+                            hidden: info.hidden || false
+                        });
+                    }
+                    
+                    // 为每个插件创建命令区域
+                    for (const [pluginName, commands] of Object.entries(pluginCommands)) {
+                        // 跳过隐藏的命令
+                        const visibleCommands = commands.filter(cmd => !cmd.hidden);
+                        if (visibleCommands.length === 0) continue;
+                        
+                        const commandGroup = document.createElement('div');
+                        commandGroup.className = 'command-group';
+                        
+                        const groupTitle = document.createElement('div');
+                        groupTitle.className = 'command-group-title';
+                        groupTitle.textContent = pluginName;
+                        
+                        commandGroup.appendChild(groupTitle);
+                        
+                        // 添加命令
+                        visibleCommands.forEach(cmd => {
+                            const cmdItem = document.createElement('div');
+                            cmdItem.className = 'command-item';
+                            cmdItem.setAttribute('data-command', `/${cmd.command}`);
+                            
+                            const cmdTitle = document.createElement('div');
+                            cmdTitle.className = 'command-title';
+                            cmdTitle.textContent = `/${cmd.command}`;
+                            
+                            const cmdDesc = document.createElement('div');
+                            cmdDesc.className = 'command-description';
+                            cmdDesc.textContent = cmd.description;
+                            
+                            cmdItem.appendChild(cmdTitle);
+                            cmdItem.appendChild(cmdDesc);
+                            
+                            cmdItem.addEventListener('click', function() {
+                                commandInput.value = this.getAttribute('data-command');
+                                commandInput.focus();
+                                charCount.textContent = `${commandInput.value.length} 个字符`;
+                            });
+                            
+                            commandGroup.appendChild(cmdItem);
+                        });
+                        
+                        commandList.appendChild(commandGroup);
+                    }
+
+                    // 检查是否有命令
+                    if (commandList.children.length === 0) {
+                        commandList.innerHTML = '<div style="padding: 1rem; color: var(--text-secondary);">没有可用的命令</div>';
+                    }
+                })
+                .catch(error => {
+                    console.error('Error fetching command list:', error);
+                    commandList.innerHTML = '<div class="error-message">无法获取命令列表，请检查后端服务</div>';
+                });
+            }
+
+            // 按钮事件
+            sendButton.addEventListener('click', sendCommand);
+            
+            // 输入框事件
+            commandInput.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    sendCommand();
+                }
+            });
+            
+            // 清空聊天记录
+            clearButton.addEventListener('click', function() {
+                // 保留第一条欢迎消息
+                const welcomeMessage = chatMessages.firstChild;
+                chatMessages.innerHTML = '';
+                chatMessages.appendChild(welcomeMessage);
+            });
+
+            // 初始化欢迎消息中的可点击命令
+            document.querySelectorAll('.clickable-command').forEach(cmd => {
+                cmd.addEventListener('click', () => {
+                    const command = cmd.getAttribute('data-command');
+                    commandInput.value = command;
+                    sendCommand();
+                });
+            });
+        });
+    </script>
+</body>
+</html> 

--- a/tools/command_tester.py
+++ b/tools/command_tester.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import sys
+import os
+import asyncio
+import json
+import argparse
+from typing import Dict, Any, Optional, List
+from pathlib import Path
+import importlib.util
+import inspect
+import re
+import traceback
+from datetime import datetime
+from aiohttp import web
+import aiohttp_cors
+import threading
+import time
+import signal
+import gc
+import platform
+import ctypes
+import subprocess
+
+# 全局变量，用于在信号处理函数中访问
+tester = None
+loop = None
+
+# 记录上次Ctrl+C的时间
+_last_sigint_time = 0
+
+def _async_raise(tid, exctype):
+    """向线程注入异常"""
+    if not isinstance(tid, int):
+        tid = tid.ident
+    if tid is None:
+        return
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, ctypes.py_object(exctype))
+    if res > 1:
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, None)
+
+def force_stop_thread(thread):
+    """强制停止线程"""
+    try:
+        _async_raise(thread.ident, SystemExit)
+    except Exception:
+        pass
+
+def cleanup_threads():
+    """清理所有非主线程"""
+    main_thread = threading.main_thread()
+    current_thread = threading.current_thread()
+    
+    for thread in threading.enumerate():
+        if thread is not main_thread and thread is not current_thread:
+            try:
+                if thread.is_alive():
+                    force_stop_thread(thread)
+            except Exception:
+                pass
+
+def force_exit():
+    """强制退出进程"""
+    bot_logger.warning("强制退出进程...")
+    os._exit(1)
+
+async def cleanup_resources():
+    """清理所有资源"""
+    global tester, loop
+    
+    try:
+        # 1. 停止 CommandTester
+        if tester and tester.running:
+            await tester.stop()
+        
+        # 2. 取消所有任务
+        if loop:
+            for task in asyncio.all_tasks(loop):
+                if task is not asyncio.current_task():
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+        
+        # 3. 关闭数据库连接
+        from utils.db import DatabaseManager
+        await DatabaseManager.close_all()
+        
+        # 4. 清理线程
+        cleanup_threads()
+        
+        # 5. 停止事件循环
+        if loop and not loop.is_closed():
+            loop.stop()
+            
+    except Exception as e:
+        bot_logger.error(f"清理资源时出错: {str(e)}")
+        return False
+        
+    return True
+
+def handle_sigint(signum, frame):
+    """处理SIGINT信号（Ctrl+C）"""
+    global _last_sigint_time
+    
+    current_time = time.time()
+    if current_time - _last_sigint_time < 2:  # 如果2秒内连续两次Ctrl+C
+        bot_logger.warning("检测到连续Ctrl+C，强制退出...")
+        force_exit()
+        return
+    
+    _last_sigint_time = current_time
+    bot_logger.warning("检测到Ctrl+C，准备退出...")
+    
+    # 设置退出标志
+    if loop:
+        loop.call_soon_threadsafe(loop.stop)
+
+def handle_exit():
+    """处理退出时的资源清理"""
+    bot_logger.info("程序正在退出...")
+    
+    # 执行资源清理
+    try:
+        cleanup_threads()
+    except Exception as e:
+        bot_logger.error(f"退出时清理资源失败: {str(e)}")
+    
+    # 垃圾回收
+    try:
+        gc.collect()
+    except Exception:
+        pass
+
+# 添加项目根目录到sys.path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# 确保配置文件存在
+config_dir = Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) / "config"
+config_file = config_dir / "config.yaml"
+
+if not config_file.exists():
+    if not config_dir.exists():
+        config_dir.mkdir(parents=True, exist_ok=True)
+    # 创建最小化的默认配置文件
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write("""# 测试环境默认配置文件
+# 这个文件用于命令测试工具，提供最小化的配置以使插件能够加载
+
+# 基础配置
+app_id: "test_app_id"
+app_token: "test_app_token"
+bot_id: "test_bot_id"
+bot_secret: "test_bot_secret"
+
+# API配置
+api:
+  endpoint: "https://api.example.com"
+  timeout: 10
+  retry_count: 3
+  
+# 数据库配置
+database:
+  path: "data/test.db"
+  backup_interval: 86400
+  
+# 日志配置
+logging:
+  level: "DEBUG"
+  file: "logs/test.log"
+  max_size: 10485760
+  
+# 插件配置
+plugins:
+  enabled: true
+  auto_load: true
+  blacklist: []
+  
+# 命令测试器专用配置
+command_tester:
+  enabled: true
+  mock_user_id: "test_user"
+  mock_group_id: "test_group"
+""")
+
+from utils.logger import bot_logger
+from core.plugin import Plugin, PluginManager
+import core.deep_search
+
+# 设置信号处理
+signal.signal(signal.SIGINT, handle_sigint)  # Ctrl+C
+if platform.system() == "Windows":
+    try:
+        signal.signal(signal.SIGBREAK, handle_sigint)  # Ctrl+Break
+    except AttributeError:
+        pass
+
+# 自定义插件管理器以增强错误处理
+class TestPluginManager(PluginManager):
+    """针对测试环境的插件管理器，增强了错误处理"""
+    
+    async def auto_discover_plugins(self):
+        """自动发现并加载所有插件，增强错误处理"""
+        bot_logger.info("开始自动发现插件...")
+        
+        # 查找plugins目录下所有Python文件
+        plugins_dir = Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) / "plugins"
+        if not plugins_dir.exists():
+            bot_logger.warning(f"插件目录不存在: {plugins_dir}")
+            return
+            
+        # 测试环境中，我们指定只加载这些插件
+        test_safe_plugins = ["deep_search_plugin"] 
+        
+        found_plugins = []
+        loaded_plugins = []
+        
+        # 优先加载测试安全的插件
+        for plugin_file in plugins_dir.glob("*.py"):
+            plugin_name = plugin_file.stem
+            if plugin_name.startswith("__"):
+                continue
+                
+            found_plugins.append(plugin_name)
+            
+            # 判断是否在安全插件列表中
+            is_safe_plugin = plugin_name in test_safe_plugins
+            
+            if not is_safe_plugin:
+                bot_logger.info(f"跳过非测试安全插件: {plugin_name}")
+                continue
+                
+            # 加载插件模块
+            try:
+                # 构建模块名
+                module_name = f"plugins.{plugin_name}"
+                
+                # 检查是否已经导入
+                if module_name in sys.modules:
+                    module = sys.modules[module_name]
+                else:
+                    # 导入模块
+                    spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[module_name] = module
+                    spec.loader.exec_module(module)
+                
+                # 查找插件类
+                for _, obj in inspect.getmembers(module):
+                    if (inspect.isclass(obj) and 
+                        issubclass(obj, Plugin) and 
+                        obj is not Plugin):
+                        # 创建插件实例
+                        plugin = obj()
+                        await self.register_plugin(plugin)
+                        loaded_plugins.append(plugin_name)
+                        bot_logger.info(f"成功加载测试安全插件: {plugin_name}")
+                        break
+                else:
+                    bot_logger.warning(f"在模块 {plugin_name} 中找不到插件类")
+                    
+            except Exception as e:
+                bot_logger.error(f"加载插件模块 {plugin_name} 失败: {str(e)}")
+                bot_logger.debug(traceback.format_exc())
+        
+        bot_logger.info(f"插件发现完成: 发现 {len(found_plugins)} 个插件，成功加载 {len(loaded_plugins)} 个测试安全插件")
+        return loaded_plugins
+
+class MockMessageHandler:
+    """模拟消息处理器，用于命令测试"""
+    
+    def __init__(self, user_id="test_user", group_id="test_group"):
+        """初始化模拟消息处理器
+        
+        Args:
+            user_id: 模拟用户ID
+            group_id: 模拟群组ID
+        """
+        self.text_responses = []
+        self.image_responses = []
+        self.recalls = []
+        self.user_id = user_id
+        self.group_id = group_id
+        
+        # 模拟消息对象
+        class MockAuthor:
+            def __init__(self, user_id):
+                self.id = user_id
+                self.member_openid = user_id
+                
+        class MockMessage:
+            def __init__(self, user_id, group_id, content=""):
+                self.id = "mock_msg_" + datetime.now().strftime("%Y%m%d%H%M%S")
+                self.author = MockAuthor(user_id)
+                self.group_openid = group_id
+                self.content = content
+                
+        self.message = MockMessage(user_id, group_id)
+        
+    async def send_text(self, content: str) -> bool:
+        """模拟发送文本消息
+        
+        Args:
+            content: 消息内容
+            
+        Returns:
+            bool: 是否成功
+        """
+        self.text_responses.append(content)
+        return True
+        
+    async def send_image(self, image_data: bytes) -> bool:
+        """模拟发送图片消息
+        
+        Args:
+            image_data: 图片数据
+            
+        Returns:
+            bool: 是否成功
+        """
+        self.image_responses.append(image_data)
+        return True
+        
+    async def recall(self) -> bool:
+        """模拟撤回消息
+        
+        Returns:
+            bool: 是否成功
+        """
+        self.recalls.append(datetime.now())
+        return True
+        
+    def get_latest_response(self) -> Optional[str]:
+        """获取最新的文本响应
+        
+        Returns:
+            Optional[str]: 最新的文本响应
+        """
+        if self.text_responses:
+            return self.text_responses[-1]
+        return None
+        
+    def get_all_responses(self) -> List[str]:
+        """获取所有文本响应
+        
+        Returns:
+            List[str]: 所有文本响应
+        """
+        return self.text_responses
+
+# 命令测试服务
+class CommandTester:
+    """命令测试服务"""
+    
+    def __init__(self, host="127.0.0.1", port=8080):
+        """初始化命令测试服务
+        
+        Args:
+            host: 主机地址
+            port: 端口号
+        """
+        self.host = host
+        self.port = port
+        self.app = web.Application()
+        self.plugin_manager = PluginManager()
+        self.running = False
+        self.html_path = Path(__file__).parent / "command_tester.html"
+        
+        # 设置跨域
+        cors = aiohttp_cors.setup(self.app, defaults={
+            "*": aiohttp_cors.ResourceOptions(
+                allow_credentials=True,
+                expose_headers="*",
+                allow_headers="*",
+            )
+        })
+        
+        # 设置路由
+        self.app.router.add_get("/", self.handle_index)
+        self.app.router.add_static("/static", Path(__file__).parent.parent / "static")
+        
+        # 先添加API路由到应用程序
+        self.app.router.add_get("/api/command_list", self.handle_command_list)
+        self.app.router.add_post("/api/execute_command", self.handle_execute_command)
+        
+        # 然后为所有路由配置CORS
+        for route in list(self.app.router.routes()):
+            if not isinstance(route, web.StaticResource):  # 静态资源路由不需要添加CORS
+                cors.add(route)
+            
+    async def handle_index(self, request):
+        """处理首页请求
+        
+        Args:
+            request: 请求对象
+            
+        Returns:
+            响应对象
+        """
+        if not self.html_path.exists():
+            return web.Response(text="HTML文件不存在", status=404)
+            
+        with open(self.html_path, "r", encoding="utf-8") as f:
+            html_content = f.read()
+            
+        return web.Response(text=html_content, content_type="text/html")
+    
+    async def handle_command_list(self, request):
+        """处理获取命令列表请求
+        
+        Args:
+            request: 请求对象
+            
+        Returns:
+            响应对象
+        """
+        try:
+            commands = self.plugin_manager.get_command_list()
+            return web.json_response({"commands": commands})
+        except Exception as e:
+            bot_logger.error(f"获取命令列表失败: {str(e)}")
+            return web.json_response({"error": f"获取命令列表失败: {str(e)}"}, status=500)
+    
+    async def handle_execute_command(self, request):
+        """处理执行命令请求"""
+        try:
+            data = await request.json()
+            command = data.get("command", "").strip()
+            
+            if not command:
+                return web.json_response({
+                    "success": False,
+                    "error": "命令不能为空",
+                    "error_type": "ValidationError"
+                }, status=400)
+                
+            if not command.startswith("/"):
+                return web.json_response({
+                    "success": False,
+                    "error": "命令必须以/开头",
+                    "error_type": "ValidationError"
+                }, status=400)
+                
+            # 创建模拟消息处理器
+            handler = MockMessageHandler(user_id="test_user", group_id="test_group")
+            handler.message.content = command
+            
+            # 执行命令
+            if command.lower() == "/help":
+                return web.json_response({
+                    "success": True,
+                    "response": "❓需要帮助？\n请使用 /about 获取帮助信息"
+                })
+                
+            try:
+                # 尝试执行命令
+                success = await self.plugin_manager.handle_message(handler, command)
+                
+                # 获取响应
+                response = handler.get_latest_response()
+                image_data = handler.image_responses[-1] if handler.image_responses else None
+                
+                if not success and not response and not image_data:
+                    return web.json_response({
+                        "success": False,
+                        "error": "未知命令或处理失败",
+                        "error_type": "CommandError"
+                    }, status=404)
+                    
+                if not response and not image_data:
+                    return web.json_response({
+                        "success": False,
+                        "error": "命令执行成功但没有响应",
+                        "error_type": "NoResponseError"
+                    }, status=500)
+                    
+                # 如果有图片数据,转换为base64
+                image_base64 = None
+                if image_data:
+                    import base64
+                    image_base64 = base64.b64encode(image_data).decode('utf-8')
+                    
+                return web.json_response({
+                    "success": True,
+                    "response": response,
+                    "image": image_base64
+                })
+                
+            except Exception as e:
+                error_traceback = traceback.format_exc()
+                bot_logger.error(f"执行命令失败: {str(e)}\n{error_traceback}")
+                return web.json_response({
+                    "success": False,
+                    "error": str(e),
+                    "error_type": e.__class__.__name__,
+                    "traceback": error_traceback,
+                    "command": command
+                }, status=500)
+                
+        except Exception as e:
+            error_traceback = traceback.format_exc()
+            bot_logger.error(f"处理请求失败: {str(e)}\n{error_traceback}")
+            return web.json_response({
+                "success": False,
+                "error": f"处理请求失败: {str(e)}",
+                "error_type": "RequestError",
+                "traceback": error_traceback
+            }, status=500)
+    
+    async def start(self):
+        """启动服务"""
+        if self.running:
+            return
+            
+        try:
+            bot_logger.info(f"开始初始化插件...")
+            await self.plugin_manager.auto_discover_plugins()
+            bot_logger.info(f"插件初始化完成，共加载 {len(self.plugin_manager.plugins)} 个插件")
+            
+            self.runner = web.AppRunner(self.app)
+            await self.runner.setup()
+            
+            self.site = web.TCPSite(self.runner, self.host, self.port)
+            await self.site.start()
+            
+            self.running = True
+            
+            bot_logger.info(f"命令测试服务已启动 http://{self.host}:{self.port}/")
+            
+        except Exception as e:
+            bot_logger.error(f"启动服务失败: {str(e)}")
+            raise
+    
+    async def stop(self):
+        """停止服务"""
+        if not self.running:
+            return
+            
+        await self.plugin_manager.cleanup()
+        await self.runner.cleanup()
+        self.running = False
+        
+        bot_logger.info("命令测试服务已停止")
+
+# 主函数
+async def main():
+    """主函数"""
+    global tester, loop
+    
+    # 注册信号处理器
+    signal.signal(signal.SIGINT, handle_sigint)
+    if platform.system() == "Windows":
+        try:
+            signal.signal(signal.SIGBREAK, handle_sigint)
+        except AttributeError:
+            pass
+    
+    parser = argparse.ArgumentParser(description="命令测试工具")
+    parser.add_argument("--host", default="127.0.0.1", help="服务主机地址")
+    parser.add_argument("--port", type=int, default=8080, help="服务端口号")
+    args = parser.parse_args()
+    
+    tester = CommandTester(host=args.host, port=args.port)
+    loop = asyncio.get_event_loop()
+    
+    try:
+        bot_logger.info("命令测试工具启动中...")
+        await tester.start()
+        
+        bot_logger.info(f"命令测试工具已成功启动 http://{args.host}:{args.port}/")
+        bot_logger.info("按下 Ctrl+C 可以退出程序")
+        
+        # 保持运行直到收到退出信号
+        while True:
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                break
+            
+    except KeyboardInterrupt:
+        bot_logger.info("检测到键盘中断，正在退出...")
+        
+    finally:
+        # 清理资源
+        cleanup_success = await cleanup_resources()
+        if not cleanup_success:
+            bot_logger.warning("资源清理可能不完整")
+        
+        # 确保事件循环停止
+        if loop and not loop.is_closed():
+            loop.stop()
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        bot_logger.critical(f"程序异常退出: {str(e)}")
+        traceback.print_exc()
+        force_exit() 

--- a/tools/command_tester_readme.md
+++ b/tools/command_tester_readme.md
@@ -1,0 +1,57 @@
+# 命令测试工具
+
+这个工具允许你在不启动QQ机器人服务的情况下测试机器人的所有命令
+
+## 为什么要用
+
+之前的方法是和生产环境的bot用一个机器人账号，然后来测试。这样的缺点是：
+
+- 服务器和本地会生成两条消息
+- 有可能被QQ做去重
+- 如果单开的话，本地环境不如生产环境稳定
+
+## 有哪些特点
+
+自己看，我懒
+
+---
+
+
+
+## 快速启动
+
+一键式：
+
+```bash
+python bot.py -local
+```
+
+手动：
+
+Windows
+
+```bash
+pip install aiohttp aiohttp_cors ; python tools/command_tester.py
+```
+
+Linux用
+
+```bash
+pip install aiohttp aiohttp_cors && python tools/command_tester.py
+
+```
+
+
+2. 默认情况下，服务会在 `http://127.0.0.1:8080` 启动
+
+3. 使用浏览器访问该地址，即可打开命令测试界面。或者如果你现在是在用ide的话可以摁住Ctrl，然后单击这个链接。
+
+---
+
+## 其他
+
+支持自定义配置，比如说：
+
+```bash
+python tools/command_tester.py --host 0.0.0.0 --port 9000
+```


### PR DESCRIPTION
## 功能改进

### 本地测试服务器
- ✨ 添加本地测试服务器功能 ，支持命令行参数
- 启动用
```bash
python bot.py -local
```
文档也写了
- 🔧 实现测试服务器依赖的自动安装
- 🎯 优化服务器启动错误处理

### 加了一个新命令 /ds

### UI优化
- 💄 优化排名页面的颜色对比度
- 🎨 改进页面布局和视觉效果

### 技术细节
- 使用命令行参数 `-local` 启动测试服务器
- 自动检测和安装必要的依赖（aiohttp、aiohttp_cors）
- 优化了排名页面的样式和布局

其他没有什么灾难性更改，都和之前一样。