### PR TITLE
feat(translation): add translation support for leaderboard types

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -41,3 +41,8 @@ server:
 season:
   current: "s5"  # 当前赛季
   update_interval: 90  # 更新间隔(秒)
+
+# 翻译配置
+translation:
+  enabled: true  # 是否启用翻译功能
+  file: "data/translations.json"  # 翻译文件路径

--- a/core/club.py
+++ b/core/club.py
@@ -7,6 +7,7 @@ from utils.logger import bot_logger
 from utils.base_api import BaseAPI
 from utils.config import settings
 from core.rank import RankQuery  # 添加 RankQuery 导入
+from utils.translator import translator
 
 class ClubAPI(BaseAPI):
     """俱乐部API封装"""
@@ -91,7 +92,11 @@ class ClubQuery:
             season = board.get("leaderboard", "未知")
             rank = board.get("rank", "未知")
             value = board.get("totalValue", 0)
-            result.append(f"▎{season}: #{rank} (总分: {value:,})")
+            
+            # 使用翻译器翻译排行榜类型
+            translated_season = translator.translate_leaderboard_type(season)
+            
+            result.append(f"▎{translated_season}: #{rank} (总分: {value:,})")
             
         return "\n".join(result)
 

--- a/data/translations.json
+++ b/data/translations.json
@@ -1,0 +1,9 @@
+{
+  "leaderboard_types": {
+    "s5": "s5排位",
+    "s5sponsor": "s5粉丝",
+    "s5worldtour": "s5巡回",
+    "s5quickcash": "s5快提",
+    "s5bankit": "s5存钱"
+  }
+} 

--- a/utils/config.py
+++ b/utils/config.py
@@ -47,6 +47,10 @@ class Settings:
     CURRENT_SEASON = _config.get("season", {}).get("current", "s5")  # 当前赛季
     UPDATE_INTERVAL = _config.get("season", {}).get("update_interval", 90)  # 更新间隔(秒)
     
+    # 翻译配置
+    TRANSLATION_ENABLED = _config.get("translation", {}).get("enabled", True)  # 是否启用翻译
+    TRANSLATION_FILE = _config.get("translation", {}).get("file", "data/translations.json")  # 翻译文件路径
+    
     @property
     def api_base_url(self) -> str:
         """返回当前使用的API基础URL"""

--- a/utils/translator.py
+++ b/utils/translator.py
@@ -1,0 +1,131 @@
+import json
+import os
+from typing import Dict, Optional, Any
+from utils.config import settings
+
+class Translator:
+    """通用翻译工具类，用于处理不同类型的翻译需求"""
+    
+    _instance = None
+    
+    def __new__(cls, *args, **kwargs):
+        """单例模式，确保只有一个翻译器实例"""
+        if cls._instance is None:
+            cls._instance = super(Translator, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+    
+    def __init__(self, translation_file: str = None, auto_reload: bool = False):
+        """
+        初始化翻译器
+        
+        Args:
+            translation_file: 翻译配置文件路径，默认从系统配置获取
+            auto_reload: 每次获取翻译时是否自动重新加载配置（适用于开发环境）
+        """
+        if self._initialized:
+            return
+            
+        self.translation_file = translation_file or settings.TRANSLATION_FILE
+        self.auto_reload = auto_reload
+        self.translations = {}
+        self.enabled = settings.TRANSLATION_ENABLED  # 从系统配置读取翻译功能启用状态
+        self.load_translations()
+        self._initialized = True
+        
+        from utils.logger import bot_logger
+        bot_logger.info(f"翻译模块已{'启用' if self.enabled else '禁用'}, 配置文件: {self.translation_file}")
+    
+    def load_translations(self) -> None:
+        """从配置文件加载翻译"""
+        try:
+            if not os.path.exists(self.translation_file):
+                self.translations = {}
+                return
+                
+            with open(self.translation_file, 'r', encoding='utf-8') as f:
+                self.translations = json.load(f)
+        except Exception as e:
+            print(f"加载翻译文件时出错: {str(e)}")
+            self.translations = {}
+    
+    def enable(self) -> None:
+        """启用翻译功能"""
+        self.enabled = True
+    
+    def disable(self) -> None:
+        """禁用翻译功能"""
+        self.enabled = False
+    
+    def is_enabled(self) -> bool:
+        """检查翻译功能是否启用"""
+        return self.enabled
+    
+    def get_translation(self, key: str, category: str, default: Optional[str] = None, force: bool = False) -> str:
+        """
+        获取指定类别下特定键的翻译
+        
+        Args:
+            key: 翻译键
+            category: 翻译类别
+            default: 未找到翻译时的默认值，None表示返回原键
+            force: 是否强制翻译，无视enabled设置
+            
+        Returns:
+            翻译后的文本，如果未找到翻译且未指定默认值，则返回原键
+        """
+        # 如果翻译功能被禁用且不是强制翻译，则直接返回原始键
+        if not self.enabled and not force:
+            return key
+            
+        if self.auto_reload:
+            self.load_translations()
+            
+        if category not in self.translations:
+            return default if default is not None else key
+            
+        category_translations = self.translations.get(category, {})
+        return category_translations.get(key, default if default is not None else key)
+    
+    def translate_dict(self, data: Dict[str, Any], category: str, keys_to_translate: Optional[list] = None, force: bool = False) -> Dict[str, Any]:
+        """
+        翻译字典中的特定键
+        
+        Args:
+            data: 要翻译的字典
+            category: 翻译类别
+            keys_to_translate: 需要翻译的键列表，None表示翻译所有键
+            force: 是否强制翻译，无视enabled设置
+            
+        Returns:
+            翻译后的字典
+        """
+        # 如果翻译功能被禁用且不是强制翻译，则直接返回原始数据
+        if not self.enabled and not force:
+            return data
+            
+        result = data.copy()
+        
+        for k, v in data.items():
+            if keys_to_translate is None or k in keys_to_translate:
+                if isinstance(v, str):
+                    result[k] = self.get_translation(v, category, force=force)
+                    
+        return result
+        
+    def translate_leaderboard_type(self, leaderboard_type: str, force: bool = False) -> str:
+        """
+        翻译排行榜类型
+        
+        Args:
+            leaderboard_type: 排行榜类型
+            force: 是否强制翻译，无视enabled设置
+            
+        Returns:
+            翻译后的排行榜类型
+        """
+        return self.get_translation(leaderboard_type, "leaderboard_types", force=force)
+
+
+# 创建一个全局翻译器实例供直接导入使用
+translator = Translator() 


### PR DESCRIPTION
## Description

Adds translation support for leaderboard types to improve localization capabilities.

## Changes

- Added translation configuration in config.yaml
- Implemented translation support in ClubQuery class
- Added translation file path configuration

## Impact

This change enables localization of leaderboard types, making the bot more accessible to users of different languages.